### PR TITLE
Remove parameter from container

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   docker run --rm -it \
     -e DISPLAY=${DISPLAY} \
     -v /tmp/.X11-unix:/tmp/.X11-unix \
-    firefox ./firefox
+    firefox 
 ```
 
 ## TODO


### PR DESCRIPTION
`./firefox` isn't needed any more. You have an entrypoint so if you pass parameters to the container it should only be firefox binary parameters.
